### PR TITLE
Fix active tab selection in preset loads

### DIFF
--- a/src/views/PreviewPage.tsx
+++ b/src/views/PreviewPage.tsx
@@ -30,6 +30,13 @@ const PreviewPage: React.FC = () => {
     const [showSettings, setShowSettings] = useState(false);
     const [defaultZoom, setDefaultZoom] = usePersistedState<number>('default-zoom', 1);
 
+    // Ensure active tab always refers to an existing device
+    useEffect(() => {
+        if (!devices.some((d) => d.id === activeTab)) {
+            setActiveTab(devices[0]?.id || '');
+        }
+    }, [devices, activeTab]);
+
 
 
     // Auto-restore last used preset
@@ -108,6 +115,7 @@ const PreviewPage: React.FC = () => {
             setLayout(selected.layout);
             setFitToWidth(selected.fitToWidth);
             setDevices(selected.devices);
+            setActiveTab(selected.devices[0]?.id || '');
             setLastUsedPreset(name);
         }
     };


### PR DESCRIPTION
## Summary
- ensure `activeTab` matches the devices list
- update the selected tab when a preset is loaded

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68461dddce488320a83b32373451cfb7