### PR TITLE
Add screenshot capture utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,14 @@ A modern developer tool to preview websites across multiple devices in real-time
 - 🔁 **Import / Export Layouts**  
   Share JSON-based presets or archive your testing configurations.
 
-- 🔧 **Settings Panel**  
+- 🔧 **Settings Panel**
   Set default zoom, theme, layout behaviors, and reset all with one click.
 
-- 🔥 **Toast Notifications**  
+- 🔥 **Toast Notifications**
   Smooth user feedback using [react-hot-toast](https://react-hot-toast.com)
+
+- 📸 **One-click Screenshots**
+  Capture any device frame and automatically download the image while copying it to your clipboard.
 
 ---
 
@@ -80,7 +83,7 @@ npm run dev
 | ✅ | Custom device creation |
 | ✅ | Settings panel for default preferences |
 | ⏳ | Auto-reload iframe toggle |
-| ⏳ | Enhanced screenshot capability |
+| ✅ | Enhanced screenshot capability |
 | ⏳ | Electron version (Desktop App) |
 | ⏳ | PWA support (Installable Web App) |
 | ⏳ | AI prompt assistance for breakpoints |
@@ -104,7 +107,7 @@ src/
 
 ## 📸 Screenshots
 
-> _(Coming Soon)_
+Click the **📸** icon on any device frame to instantly grab a screenshot. The image downloads and is copied to your clipboard for quick sharing.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,15 @@
 {
   "name": "responsive-tester",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "responsive-tester",
-      "version": "0.0.0",
+      "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
+        "html2canvas": "^1.4.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.5.2"
@@ -2045,6 +2047,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2495,6 +2506,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -3613,6 +3633,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -5182,6 +5215,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -5383,6 +5425,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "6.2.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start": "electron ."
   },
   "dependencies": {
+    "html2canvas": "^1.4.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.2"

--- a/src/components/DeviceFrame.tsx
+++ b/src/components/DeviceFrame.tsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
+import html2canvas from 'html2canvas';
+import toast from 'react-hot-toast';
 
 interface Props {
     id: string;
@@ -44,6 +46,30 @@ const DeviceFrame: React.FC<Props> = ({
         setReloadKey(Date.now());
     };
 
+    const handleScreenshot = async () => {
+        if (!frameRef.current) return;
+        const canvas = await html2canvas(frameRef.current, { backgroundColor: null });
+        canvas.toBlob(async (blob) => {
+            if (!blob) return;
+            const urlObj = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = urlObj;
+            link.download = `${name}.png`;
+            link.click();
+
+            try {
+                await navigator.clipboard.write([
+                    new ClipboardItem({ 'image/png': blob }) as unknown as ClipboardItem
+                ]);
+                toast.success('Screenshot copied to clipboard');
+            } catch (err) {
+                console.error('Clipboard copy failed', err);
+            }
+
+            setTimeout(() => URL.revokeObjectURL(urlObj), 100);
+        });
+    };
+
     const scaleStyle = fitToWidth
         ? {
             width: '100%',
@@ -86,6 +112,13 @@ const DeviceFrame: React.FC<Props> = ({
                     className="text-xs bg-blue-600 text-white px-2 py-0.5 rounded hover:bg-blue-700"
                 >
                     🔄
+                </button>
+                <button
+                    onClick={handleScreenshot}
+                    title="Screenshot"
+                    className="text-xs bg-purple-600 text-white px-2 py-0.5 rounded hover:bg-purple-700"
+                >
+                    📸
                 </button>
             </div>
 


### PR DESCRIPTION
## Summary
- add `html2canvas` dependency
- implement screenshot feature on each `DeviceFrame`
- document new one-click screenshot ability
- mark screenshot roadmap item complete

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68461fbc7db483209a2f45ed81d333fd