### PR TITLE
Add PWA plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ npm install
 npm run dev
 ```
 
+### 4. Build & Preview the PWA
+
+```bash
+npm run build
+npm run preview
+```
+
+The preview server runs the production build with the PWA service worker
+enabled. Open the printed URL in your browser and you should see an option
+to install the app.
+
 ---
 
 ## 🗺️ Roadmap

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "dev": "concurrently -k \"vite\" \"wait-on http://localhost:5174 && cross-env VITE_DEV_SERVER_URL=http://localhost:5174 electron .\"",
     "build": "vite build && tsc -p tsconfig.electron.json",
-    "start": "electron ."
+    "start": "electron .",
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -37,6 +38,7 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0",
+    "vite-plugin-pwa": "^1.0.0",
     "wait-on": "^8.0.3"
   }
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,25 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Responsive Tester",
+  "short_name": "Tester",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
 import path from 'path';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      srcDir: 'public',
+      filename: 'site.webmanifest',
+    }),
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'), // ✅ resolves to /src


### PR DESCRIPTION
## Summary
- integrate vite-plugin-pwa
- define a basic site.webmanifest
- document how to build/preview the PWA

## Testing
- `npm run build`
- `npm run preview` (killed after launch)

------
https://chatgpt.com/codex/tasks/task_e_68461fc994c4832080724748339b19ce